### PR TITLE
Fixed multiple suites not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,24 @@ const path = require('path');
 let _app = null;
 function apply(app) {
   _app = app;
-  _app.args.unshift(path.join(__dirname, 'preload.js'));
-  _app.args.unshift('--require');
+
+  let hasPreload = false;
+  const preloadPath = path.join(__dirname, 'preload.js');
+
+  // Go through the app's args list and try to find the 'preload.js' file in it
+  for (var i = 0; i < _app.args.length; i++) {
+    if (_app.args[i] === preloadPath) {
+      hasPreload = true;
+      break;
+    }
+  }
+
+  // If the 'preload.js' file hasn't been added to the args list, add it
+  if (!hasPreload) {
+    _app.args.unshift(path.join(__dirname, 'preload.js'));
+    _app.args.unshift('--require');
+  }
+
   return _app;
 }
 


### PR DESCRIPTION
This PR fixes a pretty critical bug with the fake dialogs in our test suites.

The fake dialog takes over when a "open file" or a "save file" dialog is triggered inside the app.

This is needed when testing in Mocha, so our app can easily open "test" projects and execute them.

However, our tests are separated in multiple different test suites.

And the `spectron-fake-dialog` package stops working the moment the first test suite finishes and the second is started. This [guy](https://hackernoon.com/software-testing-of-electron-based-application-ti222aw2) has a similar problem.

Turns out the package adds itself to Electon's `args` many, many times. Especially after the app is stopped and reloaded (which happens when a test suite finishes and a new one starts).

Making sure that the args is modified only one time fixes the problem locally. This fork hopes to make it easily installable on other machines.